### PR TITLE
Update reveal.js submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "reveal.js"]
+	path = reveal.js
+	url = https://github.com/girldevelopit/reveal.js.git


### PR DESCRIPTION
Reveal.js wasn't being downloaded properly when the repository was cloned. This _should_ fix it.
