### PR TITLE
updating ruby sass to node sass

### DIFF
--- a/class1.html
+++ b/class1.html
@@ -184,7 +184,7 @@ header a { color: $accentColor; }</code></pre>
          <h3>Terms</h3>
          <ul>
            <li>
-            <div><span class="green">Ruby:</span> A programming language</div><br>
+            <div><span class="green">Node:</span> A programming language</div><br>
            </li>
            <li>
             <div><span class="green">Preprocessor:</span> A computer program that modifies data to conform with the input requirements of another program.
@@ -228,12 +228,15 @@ header a { color: $accentColor; }</code></pre>
         <!-- Install Sass -->
         <section>
           <h3>Installing Sass</h3>
-          <div class="left-align">First, we need to install <span class="red">Ruby</span>:
+          <div class="left-align">First, we need to install <span class="red">Node</span>:
           <ul>
-            <li>Download for Windows: <a target="_blank" href="http://rubyinstaller.org/">rubyinstaller.org</a></li>
-            <li>Mac users: you're in luck! Mac OS X comes pre-installed with Ruby. Try the following command in Terminal to make sure: </li>
+            <li>Download for Windows and Mac: <a target="_blank" href="https://nodejs.org/en/download/">https://nodejs.org/en/download/</a></li>
+            <li>Check that Node installed correctly </li>
+            <pre><code contenteditable class ="command-line">node -v</code></pre>
+            <li>Check that NPM installed correctly </li>
+            <pre><code contenteditable class ="command-line">npm -v</code></pre>
           </ul>
-          <pre><code contenteditable class ="command-line">ruby -v</code></pre>
+
           </div>
         </section>
 
@@ -241,9 +244,9 @@ header a { color: $accentColor; }</code></pre>
         <section>
           <h3>Installing Sass</h3>
           <div class = " left-align">
-            <p>Now that Ruby is installed, we can install the Sass gem.</p>
+            <p>Now that Node is installed, we can install Sass.</p>
             <p>In Terminal or Git Bash:</p>
-            <pre><code contenteditable class ="command-line">gem install sass</code></pre>
+            <pre><code contenteditable class ="command-line">npm install -g sass</code></pre>
           </div>
             <p class="fragment"><img src="images/confetti.gif" style="border: 0; width: 600px; height: 300px; box-shadow: none;"></p>
         </section>


### PR DESCRIPTION
Ruby Sass has been deprecated since March, updating to Node Sass which is the new standard https://github.com/sass/ruby-sass